### PR TITLE
Update(switch.sh): Remove deprecated creation_script, and remove mainline kernel installation due to bugs.

### DIFF
--- a/build/switch.sh
+++ b/build/switch.sh
@@ -1,41 +1,34 @@
 #!/bin/sh
 
+# Initialise the development by grabbing assets
 apt-get install git -yq
-mkdir -p ~/creation_script/assets && cd ~/creation_script || exit
-git clone https://github.com/rollingrhinoremix/distro ~/creation_script/assets
-apt-get --allow-releaseinfo-change update -y
-apt-get --allow-releaseinfo-change dist-upgrade -y
-apt-get autopurge -y
-wget -q "https://raw.githubusercontent.com/rollingrhinoremix/rhino-deinst/master/rhino-deinst"
-chmod +x ./rhino-deinst
-mv ./rhino-deinst /usr/bin/rhino-deinst && rm rf ./rhino-deinst
-mv ~/creation_script/assets/rolling_rhino.png /usr/share/backgrounds
-mv ~/creation_script/assets/rolling_rhino-dark.png /usr/share/backgrounds
-mv ~/creation_script/assets/.bashrc /etc/skel
-mv ~/creation_script/assets/.bash_aliases /etc/skel
-chmod +x ~/creation_script/assets/.sources.sh && bash ~/creation_script/assets/.sources.sh
-mv ~/creation_script/assets/.sources.sh /etc/skel
+mkdir -p ~/creation/assets && cd ~/creation || exit
+git clone https://github.com/rollingrhinoremix/assets-desktop ~/creation/assets
+# Perform system upgrade
+apt-get update -y
+apt-get upgrade -y
+apt autoremove -y
+# Move all required assets to the correct directories
+mv ~/creation/assets/rolling_rhino.png /usr/share/backgrounds
+mv ~/creation/assets/rolling_rhino-dark.png /usr/share/backgrounds
+mv ~/creation/assets/.bashrc /etc/skel
+mv ~/creation/assets/.sources.sh /etc/skel
 rm -rf /etc/os-release
-mv ~/creation_script/assets/os-release /etc
+mv ~/creation/assets/os-release /etc
 rm -rf /usr/share/glib-2.0/schemas/10_ubuntu-settings.gschema.override
-mv ~/creation_script/assets/10_ubuntu-settings.gschema.override /usr/share/glib-2.0/schemas
-# Install rhino-config onto system
-mkdir ~/creation_script/rhino-config
-cd ~/creation_script/rhino-config || exit
-wget -nv https://github.com/rollingrhinoremix/rhino-config/releases/download/v2.0.1/rhino-config
-chmod +x ~/creation_script/rhino-config/rhino-config
-mv ~/creation_script/rhino-config/rhino-config /usr/bin
-# Download the mainline Linux kernel packages
-mkdir ~/creation_script/kernel
-cd ~/creation_script/kernel || exit
-wget -q --show-progress --progress=bar:force https://kernel.ubuntu.com/~kernel-ppa/mainline/v5.17.7/amd64/linux-headers-5.17.7-051707-generic_5.17.7-051707.202205121146_amd64.deb
-wget -q --show-progress --progress=bar:force https://kernel.ubuntu.com/~kernel-ppa/mainline/v5.17.7/amd64/linux-headers-5.17.7-051707_5.17.7-051707.202205121146_all.deb
-wget -q --show-progress --progress=bar:force https://kernel.ubuntu.com/~kernel-ppa/mainline/v5.17.7/amd64/linux-image-unsigned-5.17.7-051707-generic_5.17.7-051707.202205121146_amd64.deb
-wget -q --show-progress --progress=bar:force https://kernel.ubuntu.com/~kernel-ppa/mainline/v5.17.7/amd64/linux-modules-5.17.7-051707-generic_5.17.7-051707.202205121146_amd64.deb
-# Install the packages via apt
-sudo apt install ./*.deb
-rm -rf ~/creation_script
-cd /
+mv ~/creation/assets/10_ubuntu-settings.gschema.override /usr/share/glib-2.0/schemas
+# Install rhino-config onto system 
+mkdir ~/creation/rhino-config
+cd ~/creation/rhino-config
+wget https://github.com/rollingrhinoremix/rhino-config/releases/download/v2.0.1/rhino-config
+chmod +x ~/creation/rhino-config/rhino-config
+mv ~/creation/rhino-config/rhino-config /usr/bin
+# Install rhino-deinst onto system
+mkdir ~/creation/rhino-deinst
+cd ~/creation/rhino-deinst
+wget https://raw.githubusercontent.com/rollingrhinoremix/rhino-deinst/master/rhino-deinst
+chmod +x ~/creation/rhino-deinst/rhino-deinst
+mv ~/creation/rhino-deinst/rhino-deinst /usr/bin
 #Install the updated stuff...
 apt-get clean -y
 apt-get --allow-releaseinfo-change update -y


### PR DESCRIPTION
Update the switch.sh file to not depend on the deprecated creation_script repository. I have also removed the mainline kernel being installed by default due to issues with the 5.17.8 kernel and Intel wireless drivers. Due to this lack of stability posed by the Ubuntu mainline kernel, we will not be using it as the default Linux kernel.
