### PR TITLE
fix(switch.sh): Fix repo name for the assets repository.

### DIFF
--- a/build/switch.sh
+++ b/build/switch.sh
@@ -3,7 +3,7 @@
 # Initialise the development by grabbing assets
 apt-get install git -yq
 mkdir -p ~/creation/assets && cd ~/creation || exit
-git clone https://github.com/rollingrhinoremix/assets-desktop ~/creation/assets
+git clone https://github.com/rollingrhinoremix/assets ~/creation/assets
 # Perform system upgrade
 apt-get update -y
 apt-get upgrade -y


### PR DESCRIPTION
Fix the repository name for the assets directory from assets-desktop to just assets, as the directory was renamed following the changes that are going to be happening to the minimal disk image.
