### PR TITLE
fix(make_release.yml): install cd-boot-images-amd64 through apt

### DIFF
--- a/.github/workflows/make_release.yml
+++ b/.github/workflows/make_release.yml
@@ -15,10 +15,7 @@ jobs:
          sudo rm -rf /opt/ghc
          sudo rm -rf "/usr/local/share/boost"
          sudo rm -rf "$AGENT_TOOLSDIRECTORY"
-         sudo apt-get install xorriso coreutils squashfs-tools git axel -y
-         wget -nv "http://mirrors.kernel.org/ubuntu/pool/main/c/cd-boot-images-amd64/cd-boot-images-amd64_17_all.deb"
-         sudo dpkg -i "cd-boot-images-amd64_17_all.deb"
-         rm -rf "./cd-boot-images-amd64_17_all.deb"
+         sudo apt-get install xorriso coreutils squashfs-tools cd-boot-images git axel -y
          cd ~/
          sudo git clone -b master "https://github.com/rollingrhinoremix/RRR-builder.git" && cd ./RRR-builder
          sudo chmod +x ./fetch_build ./build/build.sh ./build/switch.sh


### PR DESCRIPTION
Hi, I'm the developer of Ubuntu Unity and this builder. I've made a few tweaks to the GitHub Workflow (you can just use the `cd-boot-images-amd64` package in the Ubuntu repos). Also, let me know if you're interested in moving this repo to https://gitlab.com/ubuntu-unity/ubuntu-remixes, where the main remixes of Ubuntu are located (Ubuntu Unity, Ubuntu Web, Ubuntu Cinnamon etc)