### PR TITLE
fix(minimal-option): Include ubuntu-desktop-minimal

### DIFF
--- a/minimal-option
+++ b/minimal-option
@@ -129,3 +129,4 @@ adwaita-icon-theme
 gcr
 emacsen-common
 ubuntu-session
+ubuntu-desktop-minimal


### PR DESCRIPTION
Flag "ubuntu-desktop-minimal" for deletion when the minimal option is selected.

Closes #31
